### PR TITLE
Bring code up to date with rc-switch r213

### DIFF
--- a/RCSwitch.h
+++ b/RCSwitch.h
@@ -5,6 +5,9 @@
   Contributors:
   - Andre Koehler / info(at)tomate-online(dot)de
   - Gordeev Andrey Vladimirovich / gordeev(at)openpyro(dot)com
+  - Skineffect / http://forum.ardumote.com/viewtopic.php?f=2&t=46
+  - Dominik Fischer / dom_fischer(at)web(dot)de
+  - Frank Oltmanns / <first name>.<last name>(at)gmail(dot)com
   
   Project home: http://code.google.com/p/rc-switch/
 
@@ -27,11 +30,13 @@
 
 #if defined(ARDUINO) && ARDUINO >= 100
     #include "Arduino.h"
+#elif defined(ENERGIA) // LaunchPad, FraunchPad and StellarPad specific
+    #include "Energia.h"	
 #else
-    #include <wiringPi.h>
-    #include <stdint.h>
-    #define NULL 0
-    #define CHANGE 1
+ #include <wiringPi.h>
+ #include <stdint.h>
+ #define NULL 0
+ #define CHANGE 1
 #ifdef __cplusplus
 extern "C"{
 #endif
@@ -45,11 +50,21 @@ typedef uint8_t byte;
 #endif
 #endif
 
+// At least for the ATTiny X4/X5, receiving has to be disabled due to
+// missing libm depencies (udivmodhi4)
+#if defined( __AVR_ATtinyX5__ ) or defined ( __AVR_ATtinyX4__ )
+#define RCSwitchDisableReceiving
+#endif
 
 // Number of maximum High/Low changes per packet.
 // We can handle up to (unsigned long) => 32 bit * 2 H/L changes per bit + 2 for sync
 #define RCSWITCH_MAX_CHANGES 67
 
+#define PROTOCOL3_SYNC_FACTOR   71
+#define PROTOCOL3_0_HIGH_CYCLES  4
+#define PROTOCOL3_0_LOW_CYCLES  11
+#define PROTOCOL3_1_HIGH_CYCLES  9
+#define PROTOCOL3_1_LOW_CYCLES   6
 
 class RCSwitch {
 
@@ -62,35 +77,45 @@ class RCSwitch {
     void switchOff(char* sGroup, int nSwitchNumber);
     void switchOn(char sFamily, int nGroup, int nDevice);
     void switchOff(char sFamily, int nGroup, int nDevice);
+    void switchOn(char* sGroup, char* sDevice);
+    void switchOff(char* sGroup, char* sDevice);
+    void switchOn(char sGroup, int nDevice);
+    void switchOff(char sGroup, int nDevice);
 
     void sendTriState(char* Code);
     void send(unsigned long Code, unsigned int length);
     void send(char* Code);
     
+    #if not defined( RCSwitchDisableReceiving )
     void enableReceive(int interrupt);
     void enableReceive();
     void disableReceive();
     bool available();
-	void resetAvailable();
+    void resetAvailable();
 	
     unsigned long getReceivedValue();
     unsigned int getReceivedBitlength();
     unsigned int getReceivedDelay();
-	unsigned int getReceivedProtocol();
+    unsigned int getReceivedProtocol();
     unsigned int* getReceivedRawdata();
+    #endif
   
     void enableTransmit(int nTransmitterPin);
     void disableTransmit();
     void setPulseLength(int nPulseLength);
     void setRepeatTransmit(int nRepeatTransmit);
+    #if not defined( RCSwitchDisableReceiving )
     void setReceiveTolerance(int nPercent);
-	void setProtocol(int nProtocol);
-	void setProtocol(int nProtocol, int nPulseLength);
+    #endif
+    void setProtocol(int nProtocol);
+    void setProtocol(int nProtocol, int nPulseLength);
   
   private:
     char* getCodeWordB(int nGroupNumber, int nSwitchNumber, boolean bStatus);
     char* getCodeWordA(char* sGroup, int nSwitchNumber, boolean bStatus);
+    char* getCodeWordA(char* sGroup, char* sDevice, boolean bStatus);
     char* getCodeWordC(char sFamily, int nGroup, int nDevice, boolean bStatus);
+    char* getCodeWordD(char group, int nDevice, boolean bStatus);
     void sendT0();
     void sendT1();
     void sendTF();
@@ -100,21 +125,30 @@ class RCSwitch {
     void transmit(int nHighPulses, int nLowPulses);
 
     static char* dec2binWzerofill(unsigned long dec, unsigned int length);
+    static char* dec2binWcharfill(unsigned long dec, unsigned int length, char fill);
     
+    #if not defined( RCSwitchDisableReceiving )
     static void handleInterrupt();
-	static bool receiveProtocol1(unsigned int changeCount);
-	static bool receiveProtocol2(unsigned int changeCount);
+    static bool receiveProtocol1(unsigned int changeCount);
+    static bool receiveProtocol2(unsigned int changeCount);
+    static bool receiveProtocol3(unsigned int changeCount);
     int nReceiverInterrupt;
+    #endif
     int nTransmitterPin;
     int nPulseLength;
     int nRepeatTransmit;
-	char nProtocol;
+    char nProtocol;
 
-	static int nReceiveTolerance;
+    #if not defined( RCSwitchDisableReceiving )
+    static int nReceiveTolerance;
     static unsigned long nReceivedValue;
     static unsigned int nReceivedBitlength;
-	static unsigned int nReceivedDelay;
-	static unsigned int nReceivedProtocol;
+    static unsigned int nReceivedDelay;
+    static unsigned int nReceivedProtocol;
+    #endif
+    /* 
+     * timings[0] contains sync timing, followed by a number of bits
+     */
     static unsigned int timings[RCSWITCH_MAX_CHANGES];
 
     

--- a/send.cpp
+++ b/send.cpp
@@ -1,39 +1,87 @@
 /*
- Usage: ./send <systemCode> <unitCode> <command>
+ Usage:
+  1) ./send <systemCode> <unitCode> <command>
+  2) ./send <familyGroup> <systemCode> <unitCode> <command>
  Command is 0 for OFF and 1 for ON
  */
 
 #include "RCSwitch.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+
+/*
+ output PIN is hardcoded for testing purposes
+ see https://projects.drogon.net/raspberry-pi/wiringpi/pins/
+ for pin mapping of the raspberry pi GPIO connector
+ */
+#define PIN 17
 
 int main(int argc, char *argv[]) {
+
+    if (argc == 1) {
+        printf("usage: send <type> <arg1> ... <argN>\n");
+        printf("  type - the type to use for sending the signal\n");
+        printf("  arg1 .. argN - depending on the type the list of arguments\n");
+        printf("\n");
+        printf("Supported types:\n");
+        printf("  dip - Switches controlled by DIP switches\n");
+        printf("        arg1 - the system code\n");
+        printf("        arg2 - the unit code\n");
+        printf("        arg3 - command\n");
+        printf("        Example: ./send dip 00001 2 0\n");
+        printf("\n");
+        printf("  rev - Switches from REV manufactor\n");
+        printf("        arg1 - the channel (a..f)\n");
+        printf("        arg2 - the device number\n");
+        printf("        arg3 - command\n");
+        printf("        Example: ./send dip a 2 0\n");
+        return -1;
+    }
+
     
-    /*
-     output PIN is hardcoded for testing purposes
-     see https://projects.drogon.net/raspberry-pi/wiringpi/pins/
-     for pin mapping of the raspberry pi GPIO connector
-     */
-    int PIN = 0;
-    char* systemCode = argv[1];
-    int unitCode = atoi(argv[2]);
-    int command  = atoi(argv[3]);
-    
-    if (wiringPiSetup () == -1) return 1;
-	printf("sending systemCode[%s] unitCode[%i] command[%i]\n", systemCode, unitCode, command);
+    if (wiringPiSetupSys () == -1) {
+        printf("WiringPiSetup failed!\n");
+        return 1;
+    }
+
 	RCSwitch mySwitch = RCSwitch();
 	mySwitch.enableTransmit(PIN);
-    
-    switch(command) {
-        case 1:
+
+    if (strcmp(argv[0], "dip")) {
+        char* systemCode = argv[2];
+        int unitCode = atoi(argv[3]);
+        int command  = atoi(argv[4]);
+
+        printf("sending systemCode[%s] unitCode[%i] command[%i]\n", systemCode, unitCode, command);
+
+        mySwitch.setPulseLength(350);
+        if (command == 1) {
             mySwitch.switchOn(systemCode, unitCode);
-            break;
-        case 0:
+            return 0;
+        } else if (command == 0) {
             mySwitch.switchOff(systemCode, unitCode);
-            break;
-        default:
-            printf("command[%i] is unsupported\n", command);
-            return -1;
+            return 0;
+        }
+
+    } else if (strcmp(argv[0], "rev")) {
+        char* channel = argv[2];
+        int device = atoi(argv[3]);
+        int command  = atoi(argv[4]);
+
+        printf("sending channel[%c] device[%i] command[%i]\n", channel[0], device, command);
+
+        mySwitch.setPulseLength(360);
+        if (command == 1) {
+            mySwitch.switchOn(channel[0], device);
+            return 0;
+        } else if (command == 0) {
+            mySwitch.switchOff(channel[0], device);
+            return 0;
+        }
+
     }
-	return 0;
+
+    printf("Unsupported invocation!\n");
+    return 1;
 }

--- a/send.cpp
+++ b/send.cpp
@@ -48,14 +48,13 @@ int main(int argc, char *argv[]) {
 	RCSwitch mySwitch = RCSwitch();
 	mySwitch.enableTransmit(PIN);
 
-    if (strcmp(argv[0], "dip")) {
+    if (strcmp(argv[1], "dip") == 0) {
         char* systemCode = argv[2];
         int unitCode = atoi(argv[3]);
         int command  = atoi(argv[4]);
 
         printf("sending systemCode[%s] unitCode[%i] command[%i]\n", systemCode, unitCode, command);
 
-        mySwitch.setPulseLength(350);
         if (command == 1) {
             mySwitch.switchOn(systemCode, unitCode);
             return 0;
@@ -64,14 +63,13 @@ int main(int argc, char *argv[]) {
             return 0;
         }
 
-    } else if (strcmp(argv[0], "rev")) {
+    } else if (strcmp(argv[1], "rev") == 0) {
         char* channel = argv[2];
         int device = atoi(argv[3]);
         int command  = atoi(argv[4]);
 
         printf("sending channel[%c] device[%i] command[%i]\n", channel[0], device, command);
 
-        mySwitch.setPulseLength(360);
         if (command == 1) {
             mySwitch.switchOn(channel[0], device);
             return 0;

--- a/send.cpp
+++ b/send.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
     }
 
     
-    if (wiringPiSetupSys () == -1) {
+    if (wiringPiSetup () == -1) {
         printf("WiringPiSetup failed!\n");
         return 1;
     }


### PR DESCRIPTION
This patch merges changes from original author to bring the implementation up to date. It merges all changes up to revison 213.

Addtionally to this, the send command was change to be able to support different types of sending commands in one command.

Usage output of `send` command:

```
usage: send <type> <arg1> ... <argN>
  type - the type to use for sending the signal
  arg1 .. argN - depending on the type the list of arguments

Supported types:
  dip - Switches controlled by DIP switches
        arg1 - the system code
        arg2 - the unit code
        arg3 - command
        Example: ./send dip 00001 2 0

  rev - Switches from REV manufactor
        arg1 - the channel (a..f)
        arg2 - the device number
        arg3 - command
        Example: ./send dip a 2 0
```

I saw that there are other people implementing REV support and I guess they are also trying to update the implementation to the recent version of the original author. Maybe parts of this patch are also in other pull request.

I think things should be merged here to avoid confusion about other pull requests and safe time for others, trying to also update to a recent version of the original author to have support for REV devices.
